### PR TITLE
Add HDF5 dataset options and CSV generation utility

### DIFF
--- a/PAMIL_multi_class/clustering.py
+++ b/PAMIL_multi_class/clustering.py
@@ -326,6 +326,11 @@ def main(args):
         args.n_classes = len(set(default_labels.values()))
         if args.model_type in ['PAMIL']:
             dataset = _build_dataset('dataset_csv/lung_subtyping_npy.csv', '1_512', default_labels)
+    elif args.task in ('fa_pt', 'custom_fa_pt'):
+        default_labels = {'FA': 0, 'PT': 1}
+        args.n_classes = len(set(default_labels.values()))
+        if args.model_type in ['PAMIL']:
+            dataset = _build_dataset('dataset_csv/hist_custom.csv', None, default_labels)
     else:
         raise NotImplementedError
 

--- a/PAMIL_multi_class/datasets/dataset_generic_h5.py
+++ b/PAMIL_multi_class/datasets/dataset_generic_h5.py
@@ -1,0 +1,276 @@
+"""Dataset utilities for loading slide-level bags stored as ``.h5`` files.
+
+This module mirrors :mod:`dataset_generic_npy` but swaps the ``numpy`` loader
+with :mod:`h5py` access so that features pre-extracted with CLAM/UNI style
+pipelines can be consumed without converting them to ``.npy`` pickles.  The
+resulting dataset returns the exact tuple expected by the rest of the PAMIL
+pipeline: ``(features, label, coords, inst_label, slide_id)``.
+
+Example
+-------
+>>> dataset = Generic_H5_MIL_Dataset(
+...     csv_path="dataset_csv/custom.csv",
+...     data_dir="/path/to/feats_h5",
+...     data_mag=None,
+... )
+>>> bag, label, coords, inst_labels, slide_id = dataset[0]
+
+The ``data_mag`` argument is optional; when provided the loader will look for
+files named ``<slide_id>_<data_mag>.h5`` to match the naming scheme used by the
+original ``.npy`` implementation.  If your files are simply ``<slide_id>.h5``
+you can leave ``data_mag`` as ``None`` (the default).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Optional, Sequence, Tuple
+
+import h5py
+import numpy as np
+import torch
+
+from .dataset_generic_npy import Generic_MIL_Dataset
+
+
+class Generic_H5_MIL_Dataset(Generic_MIL_Dataset):
+    """Load multi-instance bags from per-slide ``.h5`` files.
+
+    Parameters
+    ----------
+    data_dir:
+        Root directory that contains one ``.h5`` file per slide.
+    data_mag:
+        Optional magnification suffix appended to the slide identifier before
+        the filename extension (e.g., ``slide_123_5x.h5``).  Pass ``None`` when
+        the filenames do not include magnification information.
+    feature_key:
+        Dataset key (or ordered list of fallbacks) that stores the patch
+        embeddings inside each ``.h5`` file.  Defaults to ``("features",
+        "feature")``.
+    coord_key:
+        Dataset key (or ordered list of fallbacks) that stores the patch
+        coordinates.  Defaults to ``("coords", "index")``.
+    inst_label_key:
+        Optional dataset key (or list of keys) that stores per-patch labels.
+        When none of the supplied keys are present an empty array is returned so
+        that instance-level evaluation is skipped gracefully.
+    file_suffix:
+        Extra string inserted between the slide identifier (plus optional
+        magnification) and the ``.h5`` extension.  This is useful when the
+        exported features include additional annotations in the filename.
+    file_ext:
+        File extension used by the feature files.  The leading dot is optional.
+    use_float32:
+        Whether to convert the loaded feature tensor to ``float32``.
+    """
+
+    def __init__(
+        self,
+        data_dir: str,
+        data_mag: Optional[str] = None,
+        *,
+        feature_key: Sequence[str] | str = ("features", "feature"),
+        coord_key: Sequence[str] | str = ("coords", "index"),
+        inst_label_key: Optional[Sequence[str] | str] = ("inst_label",),
+        file_suffix: str = "",
+        file_ext: str = ".h5",
+        use_float32: bool = True,
+        **kwargs,
+    ) -> None:
+        super().__init__(data_dir=data_dir, data_mag=data_mag, **kwargs)
+
+        self._configure_h5_access(
+            feature_key=feature_key,
+            coord_key=coord_key,
+            inst_label_key=inst_label_key,
+            file_suffix=file_suffix,
+            file_ext=file_ext,
+            use_float32=use_float32,
+        )
+
+    # ---------------------------------------------------------------------
+    # Helpers shared between the dataset and the split wrappers
+    # ---------------------------------------------------------------------
+    def _configure_h5_access(
+        self,
+        *,
+        feature_key: Sequence[str] | str,
+        coord_key: Sequence[str] | str,
+        inst_label_key: Optional[Sequence[str] | str],
+        file_suffix: str,
+        file_ext: str,
+        use_float32: bool,
+    ) -> None:
+        self.feature_keys = self._coerce_keys(feature_key, default=("features", "feature"))
+        self.coord_keys = self._coerce_keys(coord_key, default=("coords", "index"))
+        self.inst_label_keys = self._coerce_keys(
+            inst_label_key,
+            default=("inst_label",),
+            allow_empty=True,
+        )
+        self.file_suffix = file_suffix or ""
+        self.file_ext = self._normalise_extension(file_ext)
+        self.use_float32 = use_float32
+
+    @staticmethod
+    def _coerce_keys(
+        keys: Optional[Sequence[str] | str],
+        *,
+        default: Optional[Iterable[str]] = None,
+        allow_empty: bool = False,
+    ) -> Tuple[str, ...]:
+        if keys is None:
+            keys = default
+
+        if keys is None:
+            return tuple() if allow_empty else ()
+
+        if isinstance(keys, str):
+            keys = (keys,)
+        elif isinstance(keys, Iterable):
+            keys = tuple(keys)
+        else:
+            raise TypeError("Keys must be a string or an iterable of strings.")
+
+        if not keys and not allow_empty:
+            raise ValueError("At least one key must be provided.")
+
+        return keys
+
+    @staticmethod
+    def _normalise_extension(file_ext: str) -> str:
+        if not file_ext:
+            file_ext = ".h5"
+        elif not file_ext.startswith("."):
+            file_ext = f".{file_ext}"
+        return file_ext
+
+    # ------------------------------------------------------------------
+    # Core dataset logic
+    # ------------------------------------------------------------------
+    def _resolve_slide_path(self, slide_id: str) -> str:
+        base_name = slide_id
+        if self.data_mag:
+            base_name = f"{base_name}_{self.data_mag}"
+        if self.file_suffix:
+            base_name = f"{base_name}{self.file_suffix}"
+        filename = f"{base_name}{self.file_ext}"
+        return os.path.join(self.data_dir, filename)
+
+    def _select_dataset(
+        self,
+        handle: h5py.File,
+        keys: Tuple[str, ...],
+        *,
+        required: bool,
+        default,
+    ):
+        for key in keys:
+            if key and key in handle:
+                return handle[key][:]
+        if required:
+            available = ", ".join(sorted(handle.keys()))
+            raise KeyError(
+                f"None of the keys {keys} were found in {handle.filename}. "
+                f"Available datasets: [{available}]"
+            )
+        return default() if callable(default) else default
+
+    def __getitem__(self, idx: int):
+        slide_id = self.slide_data['slide_id'][idx]
+        label = self.slide_data['label'][idx]
+
+        h5_path = self._resolve_slide_path(slide_id)
+        if not os.path.exists(h5_path):
+            raise FileNotFoundError(f"Slide features not found: {h5_path}")
+
+        with h5py.File(h5_path, 'r') as handle:
+            features = self._select_dataset(handle, self.feature_keys, required=True, default=None)
+            coords = self._select_dataset(
+                handle,
+                self.coord_keys,
+                required=False,
+                default=lambda: np.empty((0, 2), dtype=np.int32),
+            )
+            if self.inst_label_keys:
+                inst_label = self._select_dataset(
+                    handle,
+                    self.inst_label_keys,
+                    required=False,
+                    default=lambda: np.array([], dtype=np.int64),
+                )
+            else:
+                inst_label = np.array([], dtype=np.int64)
+
+        features = torch.from_numpy(features)
+        if self.use_float32 and features.dtype != torch.float32:
+            features = features.float()
+
+        coords = np.asarray(coords)
+        inst_label = np.asarray(inst_label)
+
+        return features, label, coords, inst_label, slide_id
+
+    # ------------------------------------------------------------------
+    # Split handling ----------------------------------------------------
+    # ------------------------------------------------------------------
+    def return_splits(self, from_id: bool = True, csv_path: Optional[str] = None):
+        base_splits = super().return_splits(from_id=from_id, csv_path=csv_path)
+
+        def _convert(split):
+            if split is None:
+                return None
+            return Generic_H5_Split(
+                split.slide_data,
+                data_dir=self.data_dir,
+                data_mag=self.data_mag,
+                num_classes=self.num_classes,
+                feature_key=self.feature_keys,
+                coord_key=self.coord_keys,
+                inst_label_key=self.inst_label_keys,
+                file_suffix=self.file_suffix,
+                file_ext=self.file_ext,
+                use_float32=self.use_float32,
+            )
+
+        return tuple(_convert(split) for split in base_splits)
+
+
+class Generic_H5_Split(Generic_H5_MIL_Dataset):
+    """Split wrapper that keeps the ``.h5`` loading logic intact."""
+
+    def __init__(
+        self,
+        slide_data,
+        *,
+        data_dir: Optional[str],
+        data_mag: Optional[str],
+        num_classes: int,
+        feature_key: Tuple[str, ...],
+        coord_key: Tuple[str, ...],
+        inst_label_key: Tuple[str, ...],
+        file_suffix: str,
+        file_ext: str,
+        use_float32: bool,
+    ) -> None:
+        # Bypass ``Generic_MIL_Dataset`` initialisation because the slide subset
+        # is already prepared.  We simply record the attributes needed for
+        # ``__getitem__`` and other helper methods.
+        self.slide_data = slide_data
+        self.data_dir = data_dir
+        self.data_mag = data_mag
+        self.num_classes = num_classes
+        self._configure_h5_access(
+            feature_key=feature_key,
+            coord_key=coord_key,
+            inst_label_key=inst_label_key,
+            file_suffix=file_suffix,
+            file_ext=file_ext,
+            use_float32=use_float32,
+        )
+        self.slide_cls_ids = [np.where(self.slide_data['label'] == i)[0] for i in range(self.num_classes)]
+
+    def __len__(self) -> int:
+        return len(self.slide_data)

--- a/PAMIL_multi_class/main.py
+++ b/PAMIL_multi_class/main.py
@@ -311,6 +311,15 @@ elif args.task == 'lung_subtype':
             '1_512',
             default_labels,
         )
+elif args.task in ('fa_pt', 'custom_fa_pt'):
+    default_labels = {'FA': 0, 'PT': 1}
+    args.n_classes = len(set(default_labels.values()))
+    if args.model_type in ['PAMIL']:
+        dataset = _build_dataset(
+            'dataset_csv/hist_custom.csv',
+            None,
+            default_labels,
+        )
 else:
     raise NotImplementedError
 

--- a/PAMIL_multi_class/main.py
+++ b/PAMIL_multi_class/main.py
@@ -11,6 +11,7 @@ from utils.utils import *
 from utils.core_utils import train
 
 from datasets.dataset_generic_npy import Generic_MIL_Dataset
+from datasets.dataset_generic_h5 import Generic_H5_MIL_Dataset
 
 
 # pytorch imports
@@ -102,8 +103,8 @@ parser.add_argument('--early_stopping', action='store_true', default=False, help
 parser.add_argument('--opt', type=str, choices = ['adam', 'sgd'], default='adam')
 parser.add_argument('--drop_out', action='store_true', default=False, help='enabel dropout (p=0.25)')
 parser.add_argument('--task', type=str)
-parser.add_argument('--model_type', type=str, choices=['wsod', 'wsod_nic','wsod_nic_single','nicwss','clam_sb', 'clam_mb', 'pmil', 'opmil', 'PAMIL'], 
-                    default='PAMIL', 
+parser.add_argument('--model_type', type=str, choices=['wsod', 'wsod_nic','wsod_nic_single','nicwss','clam_sb', 'clam_mb', 'pmil', 'opmil', 'PAMIL'],
+                    default='PAMIL',
                     help='type of model (default: clam_sb, clam w/ single attention branch)')
 
 parser.add_argument('--exp_code', type=str, help='experiment code for saving results')
@@ -111,10 +112,37 @@ parser.add_argument('--weighted_sample', action='store_true', default=False, hel
 parser.add_argument('--model_size', type=str, choices=['small', 'big'], default='small', help='size of model, does not affect mil')
 parser.add_argument('--fea_dim', type=int, default=1024,
                      help='the original dimensions of patch embedding')
-parser.add_argument('--load_checkpoint', action='store_true', default=False, 
+parser.add_argument('--load_checkpoint', action='store_true', default=False,
                     help='if load the model checkpoint')
 parser.add_argument('--bag_loss', type=str, choices=['svm', 'ce', 'bce'], default='ce',
                      help='slide-level classification loss function (default: ce)')
+
+# dataset configuration -------------------------------------------------------
+parser.add_argument('--csv_path', type=str, default=None,
+                    help='Optional override for the slide-level metadata CSV. '
+                         'Defaults to the canonical file for each task.')
+parser.add_argument('--data_mag', type=str, default=None,
+                    help='Override the magnification suffix appended to slide IDs '
+                         'when resolving feature file names.')
+parser.add_argument('--label_map', nargs='+', default=None,
+                    help='Override the default label mapping using KEY=VALUE pairs '
+                         '(e.g. FA=0 PT=1).')
+parser.add_argument('--feature_format', choices=['npy', 'h5'], default='npy',
+                    help='Storage backend for slide-level feature files.')
+parser.add_argument('--h5_feature_key', nargs='+', default=None,
+                    help='Dataset keys that contain patch embeddings inside each HDF5 file.')
+parser.add_argument('--h5_coord_key', nargs='+', default=None,
+                    help='Dataset keys that contain patch coordinates inside each HDF5 file.')
+parser.add_argument('--h5_inst_key', nargs='+', default=None,
+                    help='Dataset keys that contain instance labels inside each HDF5 file. '
+                         "Use 'none' to disable instance label loading.")
+parser.add_argument('--h5_file_suffix', type=str, default='',
+                    help='Additional string inserted between the slide identifier '
+                         'and the file extension when reading HDF5 features.')
+parser.add_argument('--h5_file_ext', type=str, default='.h5',
+                    help='File extension used for HDF5 feature files.')
+parser.add_argument('--h5_keep_dtype', action='store_true', default=False,
+                    help='Preserve the on-disk dtype instead of converting features to float32.')
 
 ### proto attention specific 
 parser.add_argument('--num_protos', type=int, default=10, help='the number of protos')
@@ -155,6 +183,76 @@ def seed_torch(seed=7):
 seed_torch(args.seed)
 
 encoding_size = 1024
+
+
+def _parse_label_map(pairs):
+    if not pairs:
+        return None
+    mapping = {}
+    for pair in pairs:
+        if '=' not in pair:
+            raise ValueError(f"Invalid label_map entry '{pair}'. Expected KEY=VALUE format.")
+        key, value = pair.split('=', 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise ValueError(f"Invalid label_map entry '{pair}'.")
+        mapping[key] = int(value)
+    return mapping
+
+
+def _parse_h5_keys(values, *, allow_empty=False):
+    if values is None:
+        return None
+    if allow_empty and len(values) == 1 and values[0].lower() == 'none':
+        return tuple()
+    return tuple(values)
+
+
+def _resolve_dataset_class():
+    if args.feature_format == 'h5':
+        return Generic_H5_MIL_Dataset
+    return Generic_MIL_Dataset
+
+
+def _resolve_data_mag(default_value, dataset_cls):
+    value = args.data_mag if args.data_mag is not None else default_value
+    if dataset_cls is Generic_H5_MIL_Dataset and isinstance(value, str):
+        if value.strip() == '' or value.lower() == 'none':
+            return None
+    return value
+
+
+def _build_dataset(default_csv, default_data_mag, label_dict):
+    label_override = _parse_label_map(args.label_map)
+    dataset_cls = _resolve_dataset_class()
+    csv_path = args.csv_path if args.csv_path else default_csv
+    data_mag = _resolve_data_mag(default_data_mag, dataset_cls)
+
+    dataset_kwargs = dict(
+        csv_path=csv_path,
+        data_dir=args.data_root_dir,
+        data_mag=data_mag,
+        shuffle=False,
+        seed=10,
+        print_info=True,
+        label_dict=label_override if label_override is not None else label_dict,
+        patient_strat=False,
+        ignore=[],
+    )
+
+    if dataset_cls is Generic_H5_MIL_Dataset:
+        dataset_kwargs.update(
+            feature_key=_parse_h5_keys(args.h5_feature_key),
+            coord_key=_parse_h5_keys(args.h5_coord_key),
+            inst_label_key=_parse_h5_keys(args.h5_inst_key, allow_empty=True),
+            file_suffix=args.h5_file_suffix,
+            file_ext=args.h5_file_ext,
+            use_float32=not args.h5_keep_dtype,
+        )
+
+    return dataset_cls(**dataset_kwargs)
+
 settings = {'num_splits': args.k, 
             'k_start': args.k_start,
             'k_end': args.k_end,
@@ -183,45 +281,43 @@ settings = {'num_splits': args.k,
 
 print('\nLoad Dataset')
 
+dataset = None
+
 if args.task == 'renal_subtype_yfy':
-    args.n_classes=3
+    default_labels = {'ccrcc': 0, 'prcc': 1, 'chrcc': 2}
+    args.n_classes = len(set(default_labels.values()))
     if args.model_type in ['PAMIL']:
-        dataset = Generic_MIL_Dataset(csv_path = 'dataset_csv/renal_subtyping_yfy_npy.csv',
-                            data_dir = os.path.join(args.data_root_dir),
-                            data_mag = '0_1024',
-                            shuffle = False, 
-                            seed = 10, 
-                            print_info = True,
-                            label_dict = {'ccrcc':0, 'prcc':1, 'chrcc':2},
-                            patient_strat= False,
-                            ignore=[])
+        dataset = _build_dataset(
+            'dataset_csv/renal_subtyping_yfy_npy.csv',
+            '0_1024',
+            default_labels,
+        )
 elif args.task == 'renal_subtype':
-    args.n_classes=3
+    default_labels = {'ccrcc': 0, 'prcc': 1, 'chrcc': 2}
+    args.n_classes = len(set(default_labels.values()))
     if args.model_type in ['PAMIL']:
-        dataset = Generic_MIL_Dataset(csv_path = 'dataset_csv/renal_subtyping_npy.csv',
-                            data_dir = os.path.join(args.data_root_dir),
-                            data_mag = '1_512',
-                            shuffle = False, 
-                            seed = 10, 
-                            print_info = True,
-                            label_dict = {'ccrcc':0, 'prcc':1, 'chrcc':2},
-                            patient_strat= False,
-                            ignore=[])
-            
+        dataset = _build_dataset(
+            'dataset_csv/renal_subtyping_npy.csv',
+            '1_512',
+            default_labels,
+        )
+
 elif args.task == 'lung_subtype':
-    args.n_classes=2
+    default_labels = {'luad': 0, 'lusc': 1}
+    args.n_classes = len(set(default_labels.values()))
     if args.model_type in ['PAMIL']:
-        dataset = Generic_MIL_Dataset(csv_path = 'dataset_csv/lung_subtyping_npy.csv',
-                            data_dir = os.path.join(args.data_root_dir),
-                            data_mag = '1_512',
-                            shuffle = False, 
-                            seed = 10, 
-                            print_info = True,
-                            label_dict = {'luad':0, 'lusc':1},
-                            patient_strat= False,
-                            ignore=[])
+        dataset = _build_dataset(
+            'dataset_csv/lung_subtyping_npy.csv',
+            '1_512',
+            default_labels,
+        )
 else:
     raise NotImplementedError
+
+if args.model_type in ['clam_sb', 'clam_mb', 'PAMIL']:
+    if dataset is None:
+        raise ValueError('Dataset initialisation failed. Check task/model configuration.')
+    args.n_classes = dataset.num_classes
     
 if not os.path.isdir(args.results_dir):
     os.mkdir(args.results_dir)

--- a/PAMIL_multi_label/clustering.py
+++ b/PAMIL_multi_label/clustering.py
@@ -11,6 +11,7 @@ from sklearn.cluster import KMeans
 
 from utils.utils import *
 from datasets.dataset_generic_npy import get_split_loader, Generic_MIL_Dataset
+from datasets.dataset_generic_h5 import Generic_H5_MIL_Dataset
 from datasets.dataset_generic_npy_gastric_esd import Generic_MIL_Dataset as Generic_MIL_Dataset_gastric_esd
 
 os.environ["CUDA_VISIBLE_DEVICES"] = "3"
@@ -41,13 +42,36 @@ parser.add_argument('--fea_dim', type=int, default=1024,
                      help='the original dimensions of patch embedding')
 parser.add_argument('--k_start', type=int, default=-1, help='start fold (default: -1, last fold)')
 parser.add_argument('--k_end', type=int, default=-1, help='end fold (default: -1, first fold)')
-parser.add_argument('--subtyping', action='store_true', default=False, 
+parser.add_argument('--subtyping', action='store_true', default=False,
                      help='subtyping problem')
 
 # special for Clustering
 parser.add_argument('--num_clusters', type=int, default=8,
                     help='the number of clusters')
 parser.add_argument('--num_protos', type=int, default=10, help='the number of protos')
+
+# dataset configuration -------------------------------------------------------
+parser.add_argument('--csv_path', type=str, default=None,
+                    help='Optional override for the slide-level metadata CSV.')
+parser.add_argument('--data_mag', type=str, default=None,
+                    help='Override the magnification suffix used when locating feature files.')
+parser.add_argument('--label_map', nargs='+', default=None,
+                    help='Override the default label mapping using KEY=VALUE pairs (e.g. FA=0 PT=1).')
+parser.add_argument('--feature_format', choices=['npy', 'h5'], default='npy',
+                    help='Storage backend for slide-level feature files.')
+parser.add_argument('--h5_feature_key', nargs='+', default=None,
+                    help='Dataset keys that contain patch embeddings inside each HDF5 file.')
+parser.add_argument('--h5_coord_key', nargs='+', default=None,
+                    help='Dataset keys that contain patch coordinates inside each HDF5 file.')
+parser.add_argument('--h5_inst_key', nargs='+', default=None,
+                    help='Dataset keys that contain instance labels inside each HDF5 file. '
+                         "Use 'none' to disable instance label loading.")
+parser.add_argument('--h5_file_suffix', type=str, default='',
+                    help='Additional string inserted between the slide identifier and the file extension.')
+parser.add_argument('--h5_file_ext', type=str, default='.h5',
+                    help='File extension used for HDF5 feature files.')
+parser.add_argument('--h5_keep_dtype', action='store_true', default=False,
+                    help='Preserve the on-disk dtype instead of converting features to float32.')
 
 args = parser.parse_args()
 device=torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -80,6 +104,77 @@ def seed_torch(seed=42):
         torch.cuda.manual_seed_all(seed) # if you are using multi-GPU.
     torch.backends.cudnn.benchmark = False
     torch.backends.cudnn.deterministic = True
+
+
+def _parse_label_map(pairs):
+    if not pairs:
+        return None
+    mapping = {}
+    for pair in pairs:
+        if '=' not in pair:
+            raise ValueError(f"Invalid label_map entry '{pair}'. Expected KEY=VALUE format.")
+        key, value = pair.split('=', 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise ValueError(f"Invalid label_map entry '{pair}'.")
+        mapping[key] = int(value)
+    return mapping
+
+
+def _parse_h5_keys(values, *, allow_empty=False):
+    if values is None:
+        return None
+    if allow_empty and len(values) == 1 and values[0].lower() == 'none':
+        return tuple()
+    return tuple(values)
+
+
+def _resolve_dataset_class(base_cls):
+    if args.feature_format == 'h5':
+        if base_cls is Generic_MIL_Dataset:
+            return Generic_H5_MIL_Dataset
+        raise ValueError('HDF5 loading is not implemented for this dataset configuration.')
+    return base_cls
+
+
+def _resolve_data_mag(default_value, dataset_cls):
+    value = args.data_mag if args.data_mag is not None else default_value
+    if dataset_cls is Generic_H5_MIL_Dataset and isinstance(value, str):
+        if value.strip() == '' or value.lower() == 'none':
+            return None
+    return value
+
+
+def _build_dataset(default_csv, default_data_mag, label_dict, *, base_cls=Generic_MIL_Dataset):
+    label_override = _parse_label_map(args.label_map)
+    dataset_cls = _resolve_dataset_class(base_cls)
+    csv_path = args.csv_path if args.csv_path else default_csv
+    data_mag = _resolve_data_mag(default_data_mag, dataset_cls)
+
+    dataset_kwargs = dict(
+        csv_path=csv_path,
+        data_dir=args.data_root_dir,
+        data_mag=data_mag,
+        shuffle=False,
+        seed=10,
+        print_info=True,
+        label_dict=label_override if label_override is not None else label_dict,
+        patient_strat=False,
+        ignore=[],
+    )
+
+    if dataset_cls is Generic_H5_MIL_Dataset:
+        dataset_kwargs.update(
+            feature_key=_parse_h5_keys(args.h5_feature_key),
+            coord_key=_parse_h5_keys(args.h5_coord_key),
+            inst_label_key=_parse_h5_keys(args.h5_inst_key, allow_empty=True),
+            file_suffix=args.h5_file_suffix,
+            file_ext=args.h5_file_ext,
+            use_float32=not args.h5_keep_dtype,
+        )
+
+    return dataset_cls(**dataset_kwargs)
 
 def preprocess_features(npdata, pca):
     """Preprocess an array of features.
@@ -216,56 +311,37 @@ def reduce(args, bag_feats, k, cur):
 def main(args):
     # define dataset
     print('Define the dataset...', end=' ')
+    dataset = None
     if args.task == 'gleason_subtype':
-        args.n_classes = 3
-        label_dict_ = {'0,0,0': 0, '0,0,1': 1, '0,1,0': 2, '0,1,1': 3, 
+        label_dict_ = {'0,0,0': 0, '0,0,1': 1, '0,1,0': 2, '0,1,1': 3,
                        '1,0,0': 4, '1,0,1': 5, '1,1,0': 6, '1,1,1': 7}
-        
+        args.n_classes = len(set(label_dict_.values()))
+
         if args.model_type in ['clam_sb', 'clam_mb']:
-            dataset = Generic_MIL_Dataset(
-                csv_path = 'dataset_csv/gleason_subtyping_npy.csv',
-                data_dir = args.data_root_dir,
-                data_mag = '0_1024',
-                shuffle = False,
-                seed = 10,
-                print_info = True,
-                label_dict = label_dict_,
-                patient_strat = False, 
-                ignore = []
-        )
+            dataset = _build_dataset('dataset_csv/gleason_subtyping_npy.csv', '0_1024', label_dict_)
     elif args.task == "gastric_subtype":
-        args.n_classes = 3
-        label_dict_ = {'0,0,0': 0, '0,0,1': 1, '0,1,0': 2, '0,1,1': 3, 
+        label_dict_ = {'0,0,0': 0, '0,0,1': 1, '0,1,0': 2, '0,1,1': 3,
                     '1,0,0': 4, '1,0,1': 5, '1,1,0': 6, '1,1,1': 7}
+        args.n_classes = len(set(label_dict_.values()))
         if args.model_type in ['clam_sb', 'clam_mb']:
-            dataset = Generic_MIL_Dataset(
-                csv_path = 'dataset_csv/gastric_subtyping_npy.csv',
-                data_dir = args.data_root_dir,
-                data_mag = '1_512',
-                shuffle = False,
-                seed = 10,
-                print_info = True,
-                label_dict = label_dict_,
-                patient_strat = False, 
-                ignore = []
-        )
+            dataset = _build_dataset('dataset_csv/gastric_subtyping_npy.csv', '1_512', label_dict_)
     elif args.task == 'gastric_esd_subtype':
-        args.n_classes = 2
         label_dict_ = {'0,0': 0, '0,1': 1, '1,1': 2}
+        args.n_classes = len(set(label_dict_.values()))
         if args.model_type in ['clam_sb', 'clam_mb']:
-            dataset = Generic_MIL_Dataset_gastric_esd(
-                csv_path = 'dataset_csv/gastric_esd_subtyping_npy_new.csv',
-                data_dir = args.data_root_dir,
-                data_mag = '0_512',
-                shuffle = False,
-                seed = 10,
-                print_info = True,
-                label_dict = label_dict_,
-                patient_strat = False, 
-                ignore = []
-            )        
+            dataset = _build_dataset(
+                'dataset_csv/gastric_esd_subtyping_npy_new.csv',
+                '0_512',
+                label_dict_,
+                base_cls=Generic_MIL_Dataset_gastric_esd,
+            )
     else:
         raise NotImplementedError
+
+    if args.model_type in ['clam_sb', 'clam_mb']:
+        if dataset is None:
+            raise ValueError('Dataset initialisation failed. Check task/model configuration.')
+        args.n_classes = dataset.num_classes
     print('Done!')
     
     # define the dataloader

--- a/PAMIL_multi_label/datasets/dataset_generic_h5.py
+++ b/PAMIL_multi_label/datasets/dataset_generic_h5.py
@@ -1,0 +1,217 @@
+"""HDF5-backed dataset loader for the multi-label PAMIL pipeline."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Optional, Sequence, Tuple
+
+import h5py
+import numpy as np
+import torch
+
+from .dataset_generic_npy import Generic_MIL_Dataset
+
+
+class Generic_H5_MIL_Dataset(Generic_MIL_Dataset):
+    """Load multi-label MIL bags stored as ``.h5`` feature files."""
+
+    def __init__(
+        self,
+        data_dir: str,
+        data_mag: Optional[str] = None,
+        *,
+        feature_key: Sequence[str] | str = ("feature2", "features", "feature"),
+        coord_key: Sequence[str] | str = ("coords", "index"),
+        inst_label_key: Optional[Sequence[str] | str] = ("inst_label",),
+        file_suffix: str = "",
+        file_ext: str = ".h5",
+        use_float32: bool = True,
+        **kwargs,
+    ) -> None:
+        super().__init__(data_dir=data_dir, data_mag=data_mag, **kwargs)
+
+        self._configure_h5_access(
+            feature_key=feature_key,
+            coord_key=coord_key,
+            inst_label_key=inst_label_key,
+            file_suffix=file_suffix,
+            file_ext=file_ext,
+            use_float32=use_float32,
+        )
+
+    # Shared helpers -----------------------------------------------------
+    def _configure_h5_access(
+        self,
+        *,
+        feature_key: Sequence[str] | str,
+        coord_key: Sequence[str] | str,
+        inst_label_key: Optional[Sequence[str] | str],
+        file_suffix: str,
+        file_ext: str,
+        use_float32: bool,
+    ) -> None:
+        self.feature_keys = self._coerce_keys(feature_key, default=("feature2", "features", "feature"))
+        self.coord_keys = self._coerce_keys(coord_key, default=("coords", "index"))
+        self.inst_label_keys = self._coerce_keys(
+            inst_label_key,
+            default=("inst_label",),
+            allow_empty=True,
+        )
+        self.file_suffix = file_suffix or ""
+        self.file_ext = self._normalise_extension(file_ext)
+        self.use_float32 = use_float32
+
+    @staticmethod
+    def _coerce_keys(
+        keys: Optional[Sequence[str] | str],
+        *,
+        default: Optional[Iterable[str]] = None,
+        allow_empty: bool = False,
+    ) -> Tuple[str, ...]:
+        if keys is None:
+            keys = default
+
+        if keys is None:
+            return tuple() if allow_empty else ()
+
+        if isinstance(keys, str):
+            keys = (keys,)
+        elif isinstance(keys, Iterable):
+            keys = tuple(keys)
+        else:
+            raise TypeError("Keys must be a string or an iterable of strings.")
+
+        if not keys and not allow_empty:
+            raise ValueError("At least one key must be provided.")
+
+        return keys
+
+    @staticmethod
+    def _normalise_extension(file_ext: str) -> str:
+        if not file_ext:
+            file_ext = ".h5"
+        elif not file_ext.startswith("."):
+            file_ext = f".{file_ext}"
+        return file_ext
+
+    # Core loading -------------------------------------------------------
+    def _resolve_slide_path(self, slide_id: str) -> str:
+        base_name = slide_id
+        if self.data_mag:
+            base_name = f"{base_name}_{self.data_mag}"
+        if self.file_suffix:
+            base_name = f"{base_name}{self.file_suffix}"
+        return os.path.join(self.data_dir, f"{base_name}{self.file_ext}")
+
+    def _select_dataset(
+        self,
+        handle: h5py.File,
+        keys: Tuple[str, ...],
+        *,
+        required: bool,
+        default,
+    ):
+        for key in keys:
+            if key and key in handle:
+                return handle[key][:]
+        if required:
+            available = ", ".join(sorted(handle.keys()))
+            raise KeyError(
+                f"None of the keys {keys} were found in {handle.filename}. "
+                f"Available datasets: [{available}]"
+            )
+        return default() if callable(default) else default
+
+    def __getitem__(self, idx: int):
+        slide_id = self.slide_data['slide_id'][idx]
+        label = self.slide_data['label'][idx]
+        label = self.translabel(label)
+
+        h5_path = self._resolve_slide_path(slide_id)
+        if not os.path.exists(h5_path):
+            raise FileNotFoundError(f"Slide features not found: {h5_path}")
+
+        with h5py.File(h5_path, 'r') as handle:
+            features = self._select_dataset(handle, self.feature_keys, required=True, default=None)
+            coords = self._select_dataset(
+                handle,
+                self.coord_keys,
+                required=False,
+                default=lambda: np.empty((0, 2), dtype=np.int32),
+            )
+            if self.inst_label_keys:
+                inst_label = self._select_dataset(
+                    handle,
+                    self.inst_label_keys,
+                    required=False,
+                    default=lambda: np.array([], dtype=np.int64),
+                )
+            else:
+                inst_label = np.array([], dtype=np.int64)
+
+        features = torch.from_numpy(features)
+        if self.use_float32 and features.dtype != torch.float32:
+            features = features.float()
+
+        coords = np.asarray(coords)
+        inst_label = np.asarray(inst_label)
+
+        return features, label, coords, inst_label, slide_id
+
+    # Split handling -----------------------------------------------------
+    def return_splits(self, from_id: bool = True, csv_path: Optional[str] = None):
+        base_splits = super().return_splits(from_id=from_id, csv_path=csv_path)
+
+        def _convert(split):
+            if split is None:
+                return None
+            return Generic_H5_Split(
+                split.slide_data,
+                data_dir=self.data_dir,
+                data_mag=self.data_mag,
+                num_classes=self.num_classes,
+                feature_key=self.feature_keys,
+                coord_key=self.coord_keys,
+                inst_label_key=self.inst_label_keys,
+                file_suffix=self.file_suffix,
+                file_ext=self.file_ext,
+                use_float32=self.use_float32,
+            )
+
+        return tuple(_convert(split) for split in base_splits)
+
+
+class Generic_H5_Split(Generic_H5_MIL_Dataset):
+    """Split wrapper preserving the HDF5 loading behaviour."""
+
+    def __init__(
+        self,
+        slide_data,
+        *,
+        data_dir: Optional[str],
+        data_mag: Optional[str],
+        num_classes: int,
+        feature_key: Tuple[str, ...],
+        coord_key: Tuple[str, ...],
+        inst_label_key: Tuple[str, ...],
+        file_suffix: str,
+        file_ext: str,
+        use_float32: bool,
+    ) -> None:
+        self.slide_data = slide_data
+        self.data_dir = data_dir
+        self.data_mag = data_mag
+        self.num_classes = num_classes
+        self._configure_h5_access(
+            feature_key=feature_key,
+            coord_key=coord_key,
+            inst_label_key=inst_label_key,
+            file_suffix=file_suffix,
+            file_ext=file_ext,
+            use_float32=use_float32,
+        )
+        self.slide_cls_ids = [np.where(self.slide_data['label'] == i)[0] for i in range(self.num_classes)]
+
+    def __len__(self) -> int:
+        return len(self.slide_data)

--- a/PAMIL_multi_label/main.py
+++ b/PAMIL_multi_label/main.py
@@ -11,6 +11,7 @@ from utils.utils import *
 from utils.core_utils import train
 
 from datasets.dataset_generic_npy import Generic_MIL_Dataset
+from datasets.dataset_generic_h5 import Generic_H5_MIL_Dataset
 from datasets.dataset_generic_npy_gastric_esd import Generic_MIL_Dataset as Generic_MIL_Dataset_gastric_esd
 
 
@@ -105,8 +106,8 @@ parser.add_argument('--early_stopping', action='store_true', default=False, help
 parser.add_argument('--opt', type=str, choices = ['adam', 'sgd'], default='adam')
 parser.add_argument('--drop_out', action='store_true', default=False, help='enabel dropout (p=0.25)')
 parser.add_argument('--task', type=str)
-parser.add_argument('--model_type', type=str, choices=['wsod', 'wsod_nic','wsod_nic_single','nicwss','clam_sb', 'clam_mb', 'pmil', 'opmil', 'PAMIL'], 
-                    default='PAMIL', 
+parser.add_argument('--model_type', type=str, choices=['wsod', 'wsod_nic','wsod_nic_single','nicwss','clam_sb', 'clam_mb', 'pmil', 'opmil', 'PAMIL'],
+                    default='PAMIL',
                     help='type of model (default: clam_sb, clam w/ single attention branch)')
 
 parser.add_argument('--exp_code', type=str, help='experiment code for saving results')
@@ -114,10 +115,33 @@ parser.add_argument('--weighted_sample', action='store_true', default=False, hel
 parser.add_argument('--model_size', type=str, choices=['small', 'big'], default='small', help='size of model, does not affect mil')
 parser.add_argument('--fea_dim', type=int, default=1024,
                      help='the original dimensions of patch embedding')
-parser.add_argument('--load_checkpoint', action='store_true', default=False, 
+parser.add_argument('--load_checkpoint', action='store_true', default=False,
                     help='if load the model checkpoint')
 parser.add_argument('--bag_loss', type=str, choices=['svm', 'ce', 'bce'], default='ce',
                      help='slide-level classification loss function (default: ce)')
+
+# dataset configuration -------------------------------------------------------
+parser.add_argument('--csv_path', type=str, default=None,
+                    help='Optional override for the slide-level metadata CSV.')
+parser.add_argument('--data_mag', type=str, default=None,
+                    help='Override the magnification suffix appended to slide IDs when reading feature files.')
+parser.add_argument('--label_map', nargs='+', default=None,
+                    help='Override the default label mapping using KEY=VALUE pairs (e.g. FA=0 PT=1).')
+parser.add_argument('--feature_format', choices=['npy', 'h5'], default='npy',
+                    help='Storage backend for slide-level feature files.')
+parser.add_argument('--h5_feature_key', nargs='+', default=None,
+                    help='Dataset keys that contain patch embeddings inside each HDF5 file.')
+parser.add_argument('--h5_coord_key', nargs='+', default=None,
+                    help='Dataset keys that contain patch coordinates inside each HDF5 file.')
+parser.add_argument('--h5_inst_key', nargs='+', default=None,
+                    help='Dataset keys that contain instance labels inside each HDF5 file. '
+                         "Use 'none' to disable instance label loading.")
+parser.add_argument('--h5_file_suffix', type=str, default='',
+                    help='Additional string inserted between the slide identifier and the file extension for HDF5 files.')
+parser.add_argument('--h5_file_ext', type=str, default='.h5',
+                    help='File extension used for HDF5 feature files.')
+parser.add_argument('--h5_keep_dtype', action='store_true', default=False,
+                    help='Preserve the on-disk dtype instead of converting features to float32.')
 
 ### proto attention specific 
 parser.add_argument('--num_protos', type=int, default=10, help='the number of protos')
@@ -159,6 +183,77 @@ def seed_torch(seed=7):
 seed_torch(args.seed)
 
 encoding_size = 1024
+
+
+def _parse_label_map(pairs):
+    if not pairs:
+        return None
+    mapping = {}
+    for pair in pairs:
+        if '=' not in pair:
+            raise ValueError(f"Invalid label_map entry '{pair}'. Expected KEY=VALUE format.")
+        key, value = pair.split('=', 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise ValueError(f"Invalid label_map entry '{pair}'.")
+        mapping[key] = int(value)
+    return mapping
+
+
+def _parse_h5_keys(values, *, allow_empty=False):
+    if values is None:
+        return None
+    if allow_empty and len(values) == 1 and values[0].lower() == 'none':
+        return tuple()
+    return tuple(values)
+
+
+def _resolve_dataset_class(base_cls):
+    if args.feature_format == 'h5':
+        if base_cls is Generic_MIL_Dataset:
+            return Generic_H5_MIL_Dataset
+        raise ValueError('HDF5 loading is not implemented for this dataset configuration.')
+    return base_cls
+
+
+def _resolve_data_mag(default_value, dataset_cls):
+    value = args.data_mag if args.data_mag is not None else default_value
+    if dataset_cls is Generic_H5_MIL_Dataset and isinstance(value, str):
+        if value.strip() == '' or value.lower() == 'none':
+            return None
+    return value
+
+
+def _build_dataset(default_csv, default_data_mag, label_dict, *, base_cls=Generic_MIL_Dataset):
+    label_override = _parse_label_map(args.label_map)
+    dataset_cls = _resolve_dataset_class(base_cls)
+    csv_path = args.csv_path if args.csv_path else default_csv
+    data_mag = _resolve_data_mag(default_data_mag, dataset_cls)
+
+    dataset_kwargs = dict(
+        csv_path=csv_path,
+        data_dir=args.data_root_dir,
+        data_mag=data_mag,
+        shuffle=False,
+        seed=10,
+        print_info=True,
+        label_dict=label_override if label_override is not None else label_dict,
+        patient_strat=False,
+        ignore=[],
+    )
+
+    if dataset_cls is Generic_H5_MIL_Dataset:
+        dataset_kwargs.update(
+            feature_key=_parse_h5_keys(args.h5_feature_key),
+            coord_key=_parse_h5_keys(args.h5_coord_key),
+            inst_label_key=_parse_h5_keys(args.h5_inst_key, allow_empty=True),
+            file_suffix=args.h5_file_suffix,
+            file_ext=args.h5_file_ext,
+            use_float32=not args.h5_keep_dtype,
+        )
+
+    return dataset_cls(**dataset_kwargs)
 settings = {'num_splits': args.k, 
             'k_start': args.k_start,
             'k_end': args.k_end,
@@ -186,61 +281,50 @@ settings = {'num_splits': args.k,
 
 print('\nLoad Dataset')
 
+dataset = None
+
 if args.task == "gastric_subtype":
-    args.n_classes = 3
-    label_dict_ = {'0,0,0': 0, '0,0,1': 1, '0,1,0': 2, '0,1,1': 3, 
+    label_dict_ = {'0,0,0': 0, '0,0,1': 1, '0,1,0': 2, '0,1,1': 3,
                    '1,0,0': 4, '1,0,1': 5, '1,1,0': 6, '1,1,1': 7}
-    
+    args.n_classes = len(set(label_dict_.values()))
+
     if args.model_type in ['clam_sb', 'clam_mb', 'PAMIL']:
-        dataset = Generic_MIL_Dataset(
-            csv_path = 'dataset_csv/gastric_subtyping_npy.csv',
-            data_dir = args.data_root_dir,
-            data_mag = '1_512',
-            shuffle = False,
-            seed = 10,
-            print_info = True,
-            label_dict = label_dict_,
-            patient_strat = False, 
-            ignore = []
+        dataset = _build_dataset(
+            'dataset_csv/gastric_subtyping_npy.csv',
+            '1_512',
+            label_dict_,
         )
-      
+
 elif args.task == 'gleason_subtype':
-    args.n_classes = 3
-    label_dict_ = {'0,0,0': 0, '0,0,1': 1, '0,1,0': 2, '0,1,1': 3, 
+    label_dict_ = {'0,0,0': 0, '0,0,1': 1, '0,1,0': 2, '0,1,1': 3,
                    '1,0,0': 4, '1,0,1': 5, '1,1,0': 6, '1,1,1': 7}
-    
+    args.n_classes = len(set(label_dict_.values()))
+
     if args.model_type in ['clam_sb', 'clam_mb', 'PAMIL']:
-        dataset = Generic_MIL_Dataset(
-            csv_path = 'dataset_csv/gleason_subtyping_npy.csv',
-            data_dir = args.data_root_dir,
-            data_mag = '0_1024',
-            shuffle = False,
-            seed = 10,
-            print_info = True,
-            label_dict = label_dict_,
-            patient_strat = False, 
-            ignore = []
+        dataset = _build_dataset(
+            'dataset_csv/gleason_subtyping_npy.csv',
+            '0_1024',
+            label_dict_,
         )
 
 elif args.task == 'gastric_esd_subtype':
-    args.n_classes = 2
     label_dict_ = {'0,0': 0, '0,1': 1, '1,1': 2}
+    args.n_classes = len(set(label_dict_.values()))
     if args.model_type in ['clam_sb', 'clam_mb', 'PAMIL']:
-        dataset = Generic_MIL_Dataset_gastric_esd(
-            csv_path = 'dataset_csv/gastric_esd_subtyping_npy_new.csv',
-            data_dir = args.data_root_dir,
-            data_mag = '0_512',
-            shuffle = False,
-            seed = 10,
-            print_info = True,
-            label_dict = label_dict_,
-            patient_strat = False, 
-            ignore = []
+        dataset = _build_dataset(
+            'dataset_csv/gastric_esd_subtyping_npy_new.csv',
+            '0_512',
+            label_dict_,
+            base_cls=Generic_MIL_Dataset_gastric_esd,
         )
-
 
 else:
     raise NotImplementedError
+
+if args.model_type in ['clam_sb', 'clam_mb', 'PAMIL']:
+    if dataset is None:
+        raise ValueError('Dataset initialisation failed. Check task/model configuration.')
+    args.n_classes = dataset.num_classes
     
 if not os.path.isdir(args.results_dir):
     os.mkdir(args.results_dir)

--- a/tools/generate_slide_csv.py
+++ b/tools/generate_slide_csv.py
@@ -1,0 +1,224 @@
+"""Utility to build slide-level metadata CSVs for the PAMIL pipelines.
+
+The generated CSV follows the format consumed by :mod:`dataset_generic_npy`
+(and the HDF5 equivalent): each row describes a single slide with the
+following columns:
+
+``case_id``
+    Identifier of the patient/case. By default this mirrors the slide ID,
+    but it can be derived from the parent directory or a custom regular
+    expression when needed.
+``slide_id``
+    Stem of the feature file, optionally post-processed by a regex.
+``label``
+    Categorical label stored as a string. At training time this value is
+    mapped to an integer via the ``label_dict`` argument of the dataset
+    loader.
+
+The script is intentionally flexible so it can accommodate feature exports
+that follow different naming conventions. Common usage patterns:
+
+* Prefix-based labels (``FA 47 B1.h5`` → label ``FA``)::
+
+      python tools/generate_slide_csv.py \
+          --features-dir /path/to/feats_h5 \
+          --output-csv dataset_csv/custom.csv
+
+* Custom mapping (``FA`` → ``0``)::
+
+      python tools/generate_slide_csv.py \
+          --features-dir /path/to/feats_h5 \
+          --output-csv dataset_csv/custom.csv \
+          --label-map FA=0 PT=1
+
+* Regex-derived identifiers::
+
+      python tools/generate_slide_csv.py \
+          --features-dir /path/to/feats_h5 \
+          --output-csv dataset_csv/custom.csv \
+          --label-source regex --label-regex "^(?P<label>[A-Z]+)" \
+          --case-source regex --case-regex "^(?P<case_id>[A-Z]+\\s?\\d+)"
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+def _normalise_extension(ext: str) -> str:
+    ext = ext.strip()
+    if not ext:
+        raise ValueError("File extension cannot be empty.")
+    if not ext.startswith('.'):
+        ext = f".{ext}"
+    return ext.lower()
+
+
+def _parse_mapping(pairs: Optional[Iterable[str]]) -> Dict[str, str]:
+    if not pairs:
+        return {}
+    mapping: Dict[str, str] = {}
+    for pair in pairs:
+        if '=' not in pair:
+            raise ValueError(f"Invalid mapping entry '{pair}'. Expected KEY=VALUE format.")
+        key, value = pair.split('=', 1)
+        key = key.strip()
+        value = value.strip()
+        if not key or not value:
+            raise ValueError(f"Invalid mapping entry '{pair}'.")
+        mapping[key] = value
+    return mapping
+
+
+def _split_token(text: str) -> str:
+    tokens = re.split(r"[\s_-]+", text)
+    return tokens[0] if tokens else text
+
+
+def _regex_extract(pattern: str, text: str, group: str) -> str:
+    match = re.search(pattern, text)
+    if not match or group not in match.groupdict():
+        raise ValueError(
+            f"Pattern '{pattern}' with group '{group}' did not match text '{text}'."
+        )
+    return str(match.group(group))
+
+
+def _derive_value(source: str, *, stem: str, path: Path, regex: Optional[str], group: str) -> str:
+    if source == 'stem':
+        return stem
+    if source == 'prefix':
+        return _split_token(stem)
+    if source == 'parent':
+        return path.parent.name
+    if source == 'regex':
+        if not regex:
+            raise ValueError(f"A --{group.replace('_', '-')} regex must be provided when using 'regex' source.")
+        return _regex_extract(regex, stem, group)
+    raise ValueError(f"Unsupported source '{source}'.")
+
+
+def build_metadata(
+    features_dir: Path,
+    *,
+    extension: str,
+    recursive: bool,
+    label_source: str,
+    case_source: str,
+    label_regex: Optional[str],
+    case_regex: Optional[str],
+    label_map: Dict[str, str],
+    include_path: bool,
+) -> List[Dict[str, str]]:
+    if not features_dir.exists():
+        raise FileNotFoundError(f"Feature directory not found: {features_dir}")
+
+    pattern = f"*{extension}"
+    files = (
+        sorted(features_dir.rglob(pattern))
+        if recursive
+        else sorted(p for p in features_dir.glob(pattern) if p.is_file())
+    )
+
+    if not files:
+        raise FileNotFoundError(
+            f"No feature files with extension '{extension}' found under {features_dir}."
+        )
+
+    records: List[Dict[str, str]] = []
+    for path in files:
+        stem = path.stem
+        slide_id = stem
+
+        label_token = _derive_value(
+            label_source,
+            stem=stem,
+            path=path,
+            regex=label_regex,
+            group='label',
+        )
+        label = label_map.get(label_token, label_token)
+
+        case_id = _derive_value(
+            case_source,
+            stem=stem,
+            path=path,
+            regex=case_regex,
+            group='case_id',
+        )
+
+        record = {
+            'case_id': case_id,
+            'slide_id': slide_id,
+            'label': label,
+        }
+
+        if include_path:
+            record['path'] = str(path.relative_to(features_dir))
+
+        records.append(record)
+
+    return records
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--features-dir', type=Path, required=True,
+                        help='Directory containing one feature file per slide.')
+    parser.add_argument('--output-csv', type=Path, required=True,
+                        help='Destination CSV file (directories are created automatically).')
+    parser.add_argument('--extension', type=str, default='.h5',
+                        help='Feature file extension (default: .h5).')
+    parser.add_argument('--recursive', action='store_true',
+                        help='Recursively search for feature files in subdirectories.')
+    parser.add_argument('--label-source', choices=['prefix', 'stem', 'parent', 'regex'], default='prefix',
+                        help='How to derive the slide label from the filename (default: prefix).')
+    parser.add_argument('--case-source', choices=['stem', 'parent', 'regex'], default='stem',
+                        help='How to derive the case identifier (default: stem).')
+    parser.add_argument('--label-regex', type=str, default=None,
+                        help="Regular expression with a named 'label' group used when --label-source=regex.")
+    parser.add_argument('--case-regex', type=str, default=None,
+                        help="Regular expression with a named 'case_id' group used when --case-source=regex.")
+    parser.add_argument('--label-map', nargs='*', default=None,
+                        help='Optional KEY=VALUE pairs used to remap derived labels (e.g. FA=0 PT=1).')
+    parser.add_argument('--include-path', action='store_true',
+                        help='Include a column with the relative path to each feature file.')
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    extension = _normalise_extension(args.extension)
+    label_map = _parse_mapping(args.label_map)
+
+    records = build_metadata(
+        args.features_dir,
+        extension=extension,
+        recursive=args.recursive,
+        label_source=args.label_source,
+        case_source=args.case_source,
+        label_regex=args.label_regex,
+        case_regex=args.case_regex,
+        label_map=label_map,
+        include_path=args.include_path,
+    )
+
+    args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ['case_id', 'slide_id', 'label']
+    if args.include_path:
+        fieldnames.append('path')
+
+    with args.output_csv.open('w', newline='') as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(records)
+
+    print(f"Wrote {len(records)} entries to {args.output_csv}.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- extend both multi-class and multi-label training/clustering entry points with a configurable HDF5-backed dataset loader, CLI switches for dataset metadata overrides, and automatic class-count reconciliation
- keep the legacy NumPy path as the default while allowing optional label remapping and magnification overrides for custom datasets
- add a reusable `tools/generate_slide_csv.py` helper that enumerates feature files and writes `case_id`, `slide_id`, and `label` metadata CSVs with flexible label derivation options

## Testing
- python -m compileall -f PAMIL_multi_class/main.py PAMIL_multi_class/clustering.py PAMIL_multi_label/main.py PAMIL_multi_label/clustering.py tools/generate_slide_csv.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9ce203c483298ae34dc0097e6f42